### PR TITLE
Fix Zabbix login

### DIFF
--- a/base.go
+++ b/base.go
@@ -203,8 +203,8 @@ func (api *API) CallWithErrorParse(method string, params interface{}, result int
 
 // Login Calls "user.login" API method and fills api.Auth field.
 // This method modifies API structure and should not be called concurrently with other methods.
-func (api *API) Login(user, password string) (auth string, err error) {
-	params := map[string]string{"user": user, "password": password}
+func (api *API) Login(username, password string) (auth string, err error) {
+	params := map[string]string{"username": username, "password": password}
 	response, err := api.CallWithError("user.login", params)
 	if err != nil {
 		return


### PR DESCRIPTION
According to Zabbix 6.x docs, `user.login` API method reqiures `username` field. Code in `base.go` uses `user` field.
https://www.zabbix.com/documentation/current/en/manual/api/reference/user/login

Field changed between Zabbix 5.2 and 5.4. In 5.4 it was working due to backward compatibility, I presume.
5.4 - `username`: https://www.zabbix.com/documentation/5.4/en/manual/api/reference/user/login
5.2 - `user`: https://www.zabbix.com/documentation/5.2/en/manual/api/reference/user/login

Accepting this change will break backward compatibility with Zabbix 5.2 and earlier.

This bug breaks Zabbix Terraform provider:
```
2023-04-19T14:15:45.429+0200 [DEBUG] provider.terraform-provider-zabbix_v0.15.0: 2023/04/19 14:15:45 [TRACE] Started zabbix provider init
2023-04-19T14:15:45.429+0200 [DEBUG] provider.terraform-provider-zabbix_v0.15.0: [DEBUG] 2023/04/19 14:15:45 TLS running in insecure mode, do not use this configuration in production
2023-04-19T14:15:45.429+0200 [DEBUG] provider.terraform-provider-zabbix_v0.15.0: [DEBUG] 2023/04/19 14:15:45 Request (POST): {"jsonrpc":"2.0","method":"APIInfo.version","params":{},"id":1}
2023-04-19T14:15:45.449+0200 [DEBUG] provider.terraform-provider-zabbix_v0.15.0: [DEBUG] 2023/04/19 14:15:45 Response (200): {"jsonrpc":"2.0","result":"6.4.1","id":1}
2023-04-19T14:15:45.449+0200 [DEBUG] provider.terraform-provider-zabbix_v0.15.0: 2023/04/19 14:15:45 [TRACE] version is: 60401
2023-04-19T14:15:45.449+0200 [DEBUG] provider.terraform-provider-zabbix_v0.15.0: [DEBUG] 2023/04/19 14:15:45 Request (POST): {"jsonrpc":"2.0","method":"user.login","params":{"password":"***","user":"some user"},"id":2}
2023-04-19T14:15:45.458+0200 [DEBUG] provider.terraform-provider-zabbix_v0.15.0: [DEBUG] 2023/04/19 14:15:45 Response (200): {"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params.","data":"Invalid parameter \"/\": unexpected parameter \"user\"."},"id":2}
2023-04-19T14:15:45.459+0200 [DEBUG] provider.terraform-provider-zabbix_v0.15.0: 2023/04/19 14:15:45 [TRACE] Started zabbix provider got error: -32602 (Invalid params.): Invalid parameter "/": unexpected parameter "user".
2023-04-19T14:15:45.459+0200 [ERROR] vertex "provider[\"registry.terraform.io/tpretz/zabbix\"]" error: -32602 (Invalid params.): Invalid parameter "/": unexpected parameter "user".
2023-04-19T14:15:45.459+0200 [INFO]  backend/local: plan operation completed
╷
│ Error: -32602 (Invalid params.): Invalid parameter "/": unexpected parameter "user".
│ 
│   with provider["registry.terraform.io/tpretz/zabbix"],
│   on zabbix.tf line 10, in provider "zabbix":
│   10: provider "zabbix" {
│ 
╵
2023-04-19T14:15:45.467+0200 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/tpretz/zabbix/0.15.0/linux_amd64/terraform-provider-zabbix_v0.15.0 pid=30737
2023-04-19T14:15:45.467+0200 [DEBUG] provider: plugin exited
```